### PR TITLE
Fix: Replace INSERT with INSERT ... ON DUPLICATE KEY UPDATE for chara…

### DIFF
--- a/src/server/database/Database/Implementation/CharacterDatabase.cpp
+++ b/src/server/database/Database/Implementation/CharacterDatabase.cpp
@@ -236,8 +236,14 @@ void CharacterDatabaseConnection::DoPrepareStatements()
     PrepareStatement(CHAR_DEL_EQUIP_SET, "DELETE FROM character_equipmentsets WHERE setguid=?", CONNECTION_ASYNC);
 
     // Auras
-    PrepareStatement(CHAR_INS_AURA, "INSERT INTO character_aura (guid, casterGuid, itemGuid, spell, effectMask, recalculateMask, stackcount, amount0, amount1, amount2, base_amount0, base_amount1, base_amount2, maxDuration, remainTime, remainCharges) "
-                     "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", CONNECTION_ASYNC);
+    PrepareStatement(CHAR_INS_AURA,
+                    "INSERT INTO character_aura (guid, casterGuid, itemGuid, spell, effectMask, recalculateMask, stackcount, amount0, amount1, amount2, base_amount0, base_amount1, base_amount2, maxDuration, remainTime, remainCharges) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+                    "ON DUPLICATE KEY UPDATE "
+                    "casterGuid=VALUES(casterGuid), itemGuid=VALUES(itemGuid), spell=VALUES(spell), effectMask=VALUES(effectMask), recalculateMask=VALUES(recalculateMask), "
+                    "stackcount=VALUES(stackcount), amount0=VALUES(amount0), amount1=VALUES(amount1), amount2=VALUES(amount2), base_amount0=VALUES(base_amount0), "
+                    "base_amount1=VALUES(base_amount1), base_amount2=VALUES(base_amount2), maxDuration=VALUES(maxDuration), remainTime=VALUES(remainTime), remainCharges=VALUES(remainCharges)",
+                    CONNECTION_ASYNC);
 
     // Account data
     PrepareStatement(CHAR_SEL_ACCOUNT_DATA, "SELECT type, time, data FROM account_data WHERE accountId = ?", CONNECTION_ASYNC);


### PR DESCRIPTION
Changes Proposed:
This PR proposes changes to:

 Core (units, players, creatures, game systems).

 Scripts (bosses, spell scripts, creature scripts).

 Database (SAI, creatures, etc).

Replaces a standard INSERT INTO character_aura with INSERT ... ON DUPLICATE KEY UPDATE to avoid potential duplicate key warnings or errors during aura save operations, particularly affecting bots or characters with multiple aura changes in a short time.


SOURCE:
The changes have been validated through:

 Live research (verified in active playerbot environment under AzerothCore).

 Sniffs

 Video evidence, knowledge databases, or other public sources

 Cherry-picked from another project

Tests Performed:
This PR has been:

 Tested in-game by the author.

 Tested in-game by other community members.

 This pull request requires further testing.

How to Test the Changes:
Spawn bots using mod-playerbots.

Trigger frequent aura changes (e.g., combat, buff spam, resummons).

Observe logs for absence of prior duplicate INSERT INTO character_aura messages.

Confirm aura persistence through relogs and world reloads.

Known Issues and TODO List:
 Optional: Generalize this fix if similar issues arise for other character tables.

Environment Details:
Server OS:
Ubuntu 24.04.2 LTS (Linux 6.8.0-60-generic)

AzerothCore Version:
13edac562c57+ (built: 2025-06-01) on branch working

Database Versions:

World DB: ACDB 335.13-dev

Login DB: 2025_02_16_01.sql

Character DB: playerbots_names.sql

World DB Patch: world_playerbots_rpg_races.sql

Installed Modules:

mod-account-mounts

mod-ah-bot

mod-no-hearthstone-cooldown

mod-ollama-chat

mod-playerbots

System Libraries:

OpenSSL: 3.0.13

Boost: 1.83.0

CMake: 3.28.3

MySQL: 8.0.45

Player Stats During Test:

Players online: 1

Characters in world: 3255

Uptime at test: 1h 14m

Update loop: 39ms avg, 331ms max