### PR TITLE
quickfix: crashlog - item::CheckSoulboundTradeExpired

### DIFF
--- a/src/server/game/Entities/Item/Item.cpp
+++ b/src/server/game/Entities/Item/Item.cpp
@@ -1283,9 +1283,9 @@ bool Item::CheckSoulboundTradeExpire()
     if (!owner)
         return true; // remove from tradeable list
     
-    if (GetUInt32Value(ITEM_FIELD_CREATE_PLAYED_TIME) + 2 * HOUR < GetOwner()->GetTotalPlayedTime())
+    if (GetUInt32Value(ITEM_FIELD_CREATE_PLAYED_TIME) + 2 * HOUR < owner->GetTotalPlayedTime())
     {
-        ClearSoulboundTradeable(GetOwner());
+        ClearSoulboundTradeable(owner);
         return true; // remove from tradeable list
     }
 


### PR DESCRIPTION
Regrad crashlog: [ae28c3e1dcc4_worldserver.exe_.13-11_17-9-50.txt](https://github.com/user-attachments/files/24333076/ae28c3e1dcc4_worldserver.exe_.13-11_17-9-50.txt)

This basically only happens due playerbots imperative destroy, move items and following the default path a normal player would. The alternative would be handing the mod_playerbots and in the hope ppl wont forget. Instead this the most safe
location to prevent this.

I havent added the PR to AC itself since this situation only occurs due bot logic and item handling.
