### PR TITLE
quickfix: crashlog player::RestoreSpellMods

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -15971,9 +15971,9 @@ void Unit::CleanupBeforeRemoveFromMap(bool finalCleanup)
     if (IsInWorld()) // not in world and not being removed atm
         RemoveFromWorld();
 
-    // added for mod_playerbots crash fixes; cancel and remove pending events before aura/spellmod cleanup.
+    // Added for mod_playerbots crash fixes; cancel and remove pending events before aura/spellmod cleanup.
     // Without this SpellEvent may be cancelled later during EventProcessor destruction after auras/spellmods 
-    // are already gone leading to invalid access in Player::RestoreSpellMods on logout.
+    // are already removed and leading to invalid access in Player::RestoreSpellMods on logout.
     m_Events.KillAllEvents(false);
 
     ASSERT(GetGUID());


### PR DESCRIPTION
Regrad crashlog: [8a9030004c84_worldserver.exe_.17-12_0-16-38.txt](https://github.com/user-attachments/files/24333125/8a9030004c84_worldserver.exe_.17-12_0-16-38.txt)

With playerbots spells are triggered by AI logic without an real client/world session. Combined with async/instant logout ir can leave enqueued spellEvents while the player (aka unit) teardown has already started. As result a spell events can be cancelled later during eventProcessor destruction, after auras and spell modifiers have already been cleaned up when unlucky and giving an invalid memory access error.

With real players this process happens more controlled through a real world session, and simply wont occur since the sequence is enforced correctly in all situations.