### PR TITLE
Workaround and minor core safety check 

### DIFF
--- a/src/server/game/Groups/Group.cpp
+++ b/src/server/game/Groups/Group.cpp
@@ -350,13 +350,20 @@ bool Group::AddLeaderInvite(Player* player)
 
 void Group::RemoveInvite(Player* player)
 {
-    if (player)
-    {
-        if (!m_invitees.empty())
-            m_invitees.erase(player);
-        player->SetGroupInvite(nullptr);
-    }
+    if (!player)
+        return;
+
+    // mod_playerbots: double invite hack workaround
+    if (player->GetGroupInvite() != this)
+        return;
+
+    auto itr = m_invitees.find(player);
+    if (itr != m_invitees.end())
+        m_invitees.erase(itr);
+
+    player->SetGroupInvite(nullptr);
 }
+
 
 void Group::RemoveAllInvites()
 {


### PR DESCRIPTION
Due incorrect group handling situations as in within mapThreads. This will prevent most problems but not all since the root causes lies within the scope of playerbots. That being said the minor fixes does not hurt the default core behavior. 

Can be removed in future when or if group handling and such are correctly handled by mod_playerbots.


https://github.com/mod-playerbots/mod-playerbots/issues/2005
