### PR TITLE
Changes required to align Playerbots database structure to Azerothcore structure

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       AC_LOGIN_DATABASE_INFO: "ac-database;3306;root;${DOCKER_DB_ROOT_PASSWORD:-password};acore_auth"
       AC_WORLD_DATABASE_INFO: "ac-database;3306;root;${DOCKER_DB_ROOT_PASSWORD:-password};acore_world"
       AC_CHARACTER_DATABASE_INFO: "ac-database;3306;root;${DOCKER_DB_ROOT_PASSWORD:-password};acore_characters"
+      AC_PLAYERBOTS_DATABASE_INFO: "ac-database;3306;root;${DOCKER_DB_ROOT_PASSWORD:-password};acore_playerbots"
     volumes:
       - ${DOCKER_VOL_ETC:-./env/dist/etc}:/azerothcore/env/dist/etc
       # [osxfs optimization]: https://stackoverflow.com/a/63437557/1964544

--- a/src/server/apps/worldserver/Main.cpp
+++ b/src/server/apps/worldserver/Main.cpp
@@ -431,6 +431,10 @@ bool StartDB()
         .AddDatabase(CharacterDatabase, "Character")
         .AddDatabase(WorldDatabase, "World");
 
+#ifdef MOD_PLAYERBOTS
+    loader.AddDatabase(PlayerbotsDatabase, "Playerbots");
+#endif
+
     if (!loader.Load())
         return false;
 
@@ -483,6 +487,10 @@ void StopDB()
     CharacterDatabase.Close();
     WorldDatabase.Close();
     LoginDatabase.Close();
+
+#ifdef MOD_PLAYERBOTS
+    PlayerbotsDatabase.Close();
+#endif
 
     sScriptMgr->OnDatabasesClosing();
 
@@ -612,6 +620,9 @@ void WorldUpdateLoop()
     LoginDatabase.WarnAboutSyncQueries(false);
     CharacterDatabase.WarnAboutSyncQueries(false);
     WorldDatabase.WarnAboutSyncQueries(false);
+#ifdef MOD_PLAYERBOTS
+    PlayerbotsDatabase.WarnAboutSyncQueries(false);
+#endif
 }
 
 void SignalHandler(boost::system::error_code const& error, int /*signalNumber*/)

--- a/src/server/apps/worldserver/worldserver.conf.dist
+++ b/src/server/apps/worldserver/worldserver.conf.dist
@@ -116,38 +116,46 @@ BindIP = "0.0.0.0"
 #        Default:     "127.0.0.1;3306;acore;acore;acore_auth"       - (LoginDatabaseInfo)
 #                     "127.0.0.1;3306;acore;acore;acore_world"      - (WorldDatabaseInfo)
 #                     "127.0.0.1;3306;acore;acore;acore_characters" - (CharacterDatabaseInfo)
+#                     "127.0.0.1;3306;acore;acore;acore_playerbots" - (playerbotsDatabaseInfo)
 
-LoginDatabaseInfo     = "127.0.0.1;3306;acore;acore;acore_auth"
-WorldDatabaseInfo     = "127.0.0.1;3306;acore;acore;acore_world"
-CharacterDatabaseInfo = "127.0.0.1;3306;acore;acore;acore_characters"
+LoginDatabaseInfo      = "127.0.0.1;3306;acore;acore;acore_auth"
+WorldDatabaseInfo      = "127.0.0.1;3306;acore;acore;acore_world"
+CharacterDatabaseInfo  = "127.0.0.1;3306;acore;acore;acore_characters"
+PlayerbotsDatabaseInfo = "127.0.0.1;3306;acore;acore;acore_playerbots"
 
 #
 #    LoginDatabase.WorkerThreads
 #    WorldDatabase.WorkerThreads
 #    CharacterDatabase.WorkerThreads
+#    PlayerbotsDatabase.WorkerThreads
 #        Description: The amount of worker threads spawned to handle asynchronous (delayed) MySQL
 #                     statements. Each worker thread is mirrored with its own connection to the
 #                     MySQL server and their own thread on the MySQL server.
 #        Default:     1 - (LoginDatabase.WorkerThreads)
 #                     1 - (WorldDatabase.WorkerThreads)
 #                     1 - (CharacterDatabase.WorkerThreads)
+#                     1 - (PlayerbotsDatabase.WorkerThreads)
 
-LoginDatabase.WorkerThreads     = 1
-WorldDatabase.WorkerThreads     = 1
-CharacterDatabase.WorkerThreads = 1
+LoginDatabase.WorkerThreads      = 1
+WorldDatabase.WorkerThreads      = 1
+CharacterDatabase.WorkerThreads  = 1
+PlayerbotsDatabase.WorkerThreads = 1
 
 #
 #    LoginDatabase.SynchThreads
 #    WorldDatabase.SynchThreads
 #    CharacterDatabase.SynchThreads
+#    PlayerbotsDatabase.SynchThreads
 #        Description: The amount of MySQL connections spawned to handle.
 #        Default:     1 - (LoginDatabase.SynchThreads)
 #                     1 - (WorldDatabase.SynchThreads)
 #                     1 - (CharacterDatabase.SynchThreads)
+#                     1 - (PlayerbotsDatabase.SynchThreads)
 
-LoginDatabase.SynchThreads     = 1
-WorldDatabase.SynchThreads     = 1
-CharacterDatabase.SynchThreads = 1
+LoginDatabase.SynchThreads      = 1
+WorldDatabase.SynchThreads      = 1
+CharacterDatabase.SynchThreads  = 1
+PlayerbotsDatabase.SynchThreads = 1
 
 #
 #    MaxPingTime
@@ -288,15 +296,16 @@ FlashAtStart = 1
 #        Description: A mask that describes which databases should be updated.
 #
 #        Following flags are available
-#           DATABASE_LOGIN     = 1, // Auth database
-#           DATABASE_CHARACTER = 2, // Character database
-#           DATABASE_WORLD     = 4, // World database
+#           DATABASE_LOGIN      = 1, // Auth database
+#           DATABASE_CHARACTER  = 2, // Character database
+#           DATABASE_WORLD      = 4, // World database
+#           DATABASE_PLAYERBOTS = 8, // Playerbots database
 #
-#        Default:     7  - (All enabled)
+#        Default:     15 - (All enabled)
 #                     4  - (Enable world only)
 #                     0  - (All disabled)
 
-Updates.EnableDatabases = 7
+Updates.EnableDatabases = 15
 
 #
 #    Updates.AutoSetup

--- a/src/server/database/Database/DatabaseLoader.cpp
+++ b/src/server/database/Database/DatabaseLoader.cpp
@@ -31,6 +31,9 @@ namespace
     std::string const LOGIN_DATABASE_INFO_DEFAULT = "127.0.0.1;3306;acore;acore;acore_auth";
     std::string const WORLD_DATABASE_INFO_DEFAULT = "127.0.0.1;3306;acore;acore;acore_world";
     std::string const CHARACTER_DATABASE_INFO_DEFAULT = "127.0.0.1;3306;acore;acore;acore_characters";
+#ifdef MOD_PLAYERBOTS
+    std::string const PLAYERBOTS_DATABASE_INFO_DEFAULT = "127.0.0.1;3306;acore;acore;acore_playerbots";
+#endif
     std::string const& GetDefaultDatabaseInfo(std::string_view name)
     {
         if (name == "Login")
@@ -39,6 +42,10 @@ namespace
             return WORLD_DATABASE_INFO_DEFAULT;
         if (name == "Character")
             return CHARACTER_DATABASE_INFO_DEFAULT;
+#ifdef MOD_PLAYERBOTS
+        if (name == "Playerbots")
+            return PLAYERBOTS_DATABASE_INFO_DEFAULT;
+#endif
         return EMPTY_DATABASE_INFO;
     }
 }

--- a/src/server/database/Updater/DBUpdater.cpp
+++ b/src/server/database/Updater/DBUpdater.cpp
@@ -201,7 +201,7 @@ std::string DBUpdater<PlayerbotsDatabaseConnection>::GetSourceDirectory()
 template<>
 std::string DBUpdater<PlayerbotsDatabaseConnection>::GetBaseFilesDirectory()
 {
-    return DBUpdater<PlayerbotsDatabaseConnection>::GetSourceDirectory() + "/data/sql/playerbots/base/";
+    return DBUpdater<PlayerbotsDatabaseConnection>::GetSourceDirectory() + "/data/sql/base/db_playerbots/";
 }
 
 template<>
@@ -214,7 +214,7 @@ bool DBUpdater<PlayerbotsDatabaseConnection>::IsEnabled(uint32 const updateMask)
 template<>
 std::string DBUpdater<PlayerbotsDatabaseConnection>::GetDBModuleName()
 {
-    return "db_playerbot";
+    return "db_playerbots";
 }
 #endif
 

--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -788,6 +788,10 @@ void WorldSession::LogoutPlayer(bool save)
 
         uint32 statementIndex = CHAR_UPD_ACCOUNT_ONLINE;
         uint32 statementParam = GetAccountId();
+#ifdef MOD_PLAYERBOTS
+        statementIndex = CHAR_UPD_CHAR_OFFLINE;
+        statementParam = _player->GetGUID().GetCounter();
+#endif
         sScriptMgr->OnDatabaseSelectIndexLogout(_player, statementIndex, statementParam);
 
         //! Remove the player from the world

--- a/src/server/game/World/IWorld.h
+++ b/src/server/game/World/IWorld.h
@@ -105,9 +105,6 @@ public:
     [[nodiscard]] virtual LocaleConstant GetAvailableDbcLocale(LocaleConstant locale) const = 0;
     virtual void LoadDBVersion() = 0;
     [[nodiscard]] virtual char const* GetDBVersion() const = 0;
-#ifdef MOD_PLAYERBOTS
-    [[nodiscard]] virtual char const* GetPlayerbotsDBRevision() const = 0;
-#endif
     virtual void UpdateAreaDependentAuras() = 0;
     [[nodiscard]] virtual uint32 GetCleaningFlags() const = 0;
     virtual void   SetCleaningFlags(uint32 flags) = 0;

--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -1293,6 +1293,9 @@ void World::Update(uint32 diff)
         CharacterDatabase.KeepAlive();
         LoginDatabase.KeepAlive();
         WorldDatabase.KeepAlive();
+#ifdef MOD_PLAYERBOTS
+        PlayerbotsDatabase.KeepAlive();
+#endif
         sScriptMgr->OnDatabasesKeepAlive();
     }
 

--- a/src/server/game/World/World.h
+++ b/src/server/game/World/World.h
@@ -229,9 +229,6 @@ public:
     // used World DB version
     void LoadDBVersion() override;
     [[nodiscard]] char const* GetDBVersion() const override { return _dbVersion.c_str(); }
-#ifdef MOD_PLAYERBOTS
-    [[nodiscard]] char const* GetPlayerbotsDBRevision() const override { return m_PlayerbotsDBRevision.c_str(); }
-#endif
 
     void UpdateAreaDependentAuras() override;
 
@@ -306,9 +303,6 @@ private:
     // used versions
     std::string _dbVersion;
     uint32 _dbClientCacheVersion;
-#ifdef MOD_PLAYERBOTS
-    std::string m_PlayerbotsDBRevision;
-#endif
 
     void ProcessQueryCallbacks();
     QueryCallbackProcessor _queryProcessor;

--- a/src/server/scripts/Commands/cs_server.cpp
+++ b/src/server/scripts/Commands/cs_server.cpp
@@ -213,10 +213,6 @@ public:
         handler->PSendSysMessage("Default DBC locale: {}.\nAll available DBC locales: {}", localeNames[defaultLocale], availableLocales);
 
         handler->PSendSysMessage("Using World DB: {}", sWorld->GetDBVersion());
-#ifdef MOD_PLAYERBOTS
-        handler->PSendSysMessage("Using Playerbots DB Revision: {}", sWorld->GetPlayerbotsDBRevision());
-#endif
-        
 
         std::string lldb = "No updates found!";
         if (QueryResult resL = LoginDatabase.Query("SELECT name FROM updates ORDER BY name DESC LIMIT 1"))
@@ -237,9 +233,21 @@ public:
             lwdb = fields[0].Get<std::string>();
         }
 
+#ifdef MOD_PLAYERBOTS
+        std::string lpdb = "No updates found!";
+        if (QueryResult resP = PlayerbotsDatabase.Query("SELECT name FROM updates ORDER BY name DESC LIMIT 1"))
+        {
+            Field* fields = resP->Fetch();
+            lpdb = fields[0].Get<std::string>();
+        }
+#endif
+
         handler->PSendSysMessage("Latest LoginDatabase update: {}", lldb);
         handler->PSendSysMessage("Latest CharacterDatabase update: {}", lcdb);
         handler->PSendSysMessage("Latest WorldDatabase update: {}", lwdb);
+#ifdef MOD_PLAYERBOTS
+        handler->PSendSysMessage("Latest PlayerbotsDatabase update: {}", lpdb);
+#endif
 
         handler->PSendSysMessage("LoginDatabase queue size: {}", LoginDatabase.QueueSize());
         handler->PSendSysMessage("CharacterDatabase queue size: {}", CharacterDatabase.QueueSize());

--- a/src/tools/dbimport/Main.cpp
+++ b/src/tools/dbimport/Main.cpp
@@ -108,14 +108,20 @@ bool StartDB()
     LOG_INFO("dbimport", "Loading modules: {}", modules.empty() ? "none" : modules);
 
     DatabaseLoader loader =
-        modules.empty() ? DatabaseLoader("dbimport") :
-        (modules == "all") ? DatabaseLoader("dbimport", DatabaseLoader::DATABASE_MASK_ALL, AC_MODULES_LIST) :
-        DatabaseLoader("dbimport", DatabaseLoader::DATABASE_MASK_ALL, modules);
+        modules.empty()
+            ? DatabaseLoader("dbimport")
+            : (modules == "all"
+                ? DatabaseLoader("dbimport", DatabaseLoader::DATABASE_MASK_ALL, AC_MODULES_LIST)
+                : DatabaseLoader("dbimport", DatabaseLoader::DATABASE_MASK_ALL, modules));
 
     loader
         .AddDatabase(LoginDatabase, "Login")
         .AddDatabase(CharacterDatabase, "Character")
         .AddDatabase(WorldDatabase, "World");
+
+#ifdef MOD_PLAYERBOTS
+    loader.AddDatabase(PlayerbotsDatabase, "Playerbots");
+#endif
 
     if (!loader.Load())
         return false;
@@ -130,6 +136,10 @@ void StopDB()
     CharacterDatabase.Close();
     WorldDatabase.Close();
     LoginDatabase.Close();
+#ifdef MOD_PLAYERBOTS
+    PlayerbotsDatabase.Close();
+#endif
+
     MySQL::Library_End();
 }
 

--- a/src/tools/dbimport/dbimport.conf.dist
+++ b/src/tools/dbimport/dbimport.conf.dist
@@ -90,6 +90,7 @@ TempDir = ""
 #        Default:     "127.0.0.1;3306;acore;acore;acore_auth"       - (LoginDatabaseInfo)
 #                     "127.0.0.1;3306;acore;acore;acore_world"      - (WorldDatabaseInfo)
 #                     "127.0.0.1;3306;acore;acore;acore_characters" - (CharacterDatabaseInfo)
+#                     "127.0.0.1;3306;acore;acore;acore_playerbots" - (PlayerbotsDatabaseInfo)
 #
 #    The SSL option will enable TLS when connecting to the specified database. If not provided or
 #    any value other than 'ssl' is set, TLS will not be used.
@@ -98,6 +99,7 @@ TempDir = ""
 LoginDatabaseInfo     = "127.0.0.1;3306;acore;acore;acore_auth"
 WorldDatabaseInfo     = "127.0.0.1;3306;acore;acore;acore_world"
 CharacterDatabaseInfo = "127.0.0.1;3306;acore;acore;acore_characters"
+PlayerbotsDatabaseInfo = "127.0.0.1;3306;acore;acore;acore_playerbots"
 
 #
 #    Database.Reconnect.Seconds
@@ -126,6 +128,7 @@ Database.Reconnect.Attempts = 5
 LoginDatabase.WorkerThreads     = 1
 WorldDatabase.WorkerThreads     = 1
 CharacterDatabase.WorkerThreads = 1
+PlayerbotsDatabase.WorkerThreads = 1
 
 #
 #    LoginDatabase.SynchThreads
@@ -152,12 +155,13 @@ CharacterDatabase.SynchThreads = 1
 #           DATABASE_LOGIN     = 1, // Auth database
 #           DATABASE_CHARACTER = 2, // Character database
 #           DATABASE_WORLD     = 4, // World database
+#           DATABASE_PLAYERBOTS = 8, // Playerbots database
 #
-#        Default:     7  - (All enabled)
+#        Default:     15 - (All enabled)
 #                     4  - (Enable world only)
 #                     0  - (All disabled)
 
-Updates.EnableDatabases = 7
+Updates.EnableDatabases = 15
 
 #
 #   Updates.AllowedModules


### PR DESCRIPTION
## Changes Proposed:
**This PR proposes changes to:**
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

**Summary**
This PR extends AzerothCore’s built-in database update system to support the PlayerbotsDatabase as a first-class, core-managed database, aligned with how Auth / Characters / World are handled.

Key points:

- Adds core-level support for the DATABASE_PLAYERBOTS update mask so updates are controlled by the existing core configuration (no module-specific toggle needed).
- Integrates PlayerbotsDatabase into the same update lifecycle as other DB pools (creation/population/update flow via DBUpdater/UpdateFetcher).
- Centralizes KeepAlive() handling for PlayerbotsDatabase in the core update loop (same pattern as Login/Character/World).
- Removes/avoids the need for module-owned database loading toggles so the module does not try to “own” DB lifecycle anymore.

> [!IMPORTANT]
This PR must be merged together with the mod-playerbots PR:
https://github.com/mod-playerbots/mod-playerbots/pull/2141/

## Issues Addressed:
- Closes  (n/a)

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Apply this AzerothCore PR and mod-playerbots PR #2141.
2. Rebuild the core (worldserver/authserver) and ensure compilation succeeds.
3. Configure DB connections so the PlayerbotsDatabase is reachable (same as usual for mod-playerbots setups).
4. Ensure the core DB update system is enabled and includes the DATABASE_PLAYERBOTS mask (via the standard core configuration).
5. Start worldserver and verify:
- The Playerbots database update flow runs without ordering errors (tables created before updates that ALTER them).
- The server no longer requests/depends on any module-specific database update toggle (e.g. Playerbots.Updates.EnableDatabases).
6. Restart worldserver a second time and verify:
- No re-application of base/initialization SQL occurs.
- Only new pending updates (if any) are applied.
7. Optional regression checks:
- Normal Auth/Character/World update flow still works unchanged (no regressions in update tables, update ordering, or logs).
- Player login/logout still updates the correct offline/index statement path when playerbots is enabled.

## Known Issues and TODO List:
- [ ] None known at the time of submission.
- [ ] Additional tester coverage welcome (fresh install + existing DB upgrade paths).