### PR TITLE
Add missing charsections_dbc and emotetextsound_dbc tables

### DIFF
--- a/data/sql/base/db_world/charsections_dbc.sql
+++ b/data/sql/base/db_world/charsections_dbc.sql
@@ -1,0 +1,58 @@
+-- MySQL dump 10.13  Distrib 8.4.8, for Linux (x86_64)
+--
+-- Host: localhost    Database: acore_world
+-- ------------------------------------------------------
+-- Server version	8.4.8
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!50503 SET NAMES utf8mb4 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+--
+-- Table structure for table `charsections_dbc`
+--
+
+DROP TABLE IF EXISTS `charsections_dbc`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `charsections_dbc` (
+  `ID` int NOT NULL DEFAULT '0',
+  `RaceID` int NOT NULL DEFAULT '0',
+  `SexID` int NOT NULL DEFAULT '0',
+  `BaseSection` int NOT NULL DEFAULT '0',
+  `TextureName_1` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `TextureName_2` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `TextureName_3` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `Flags` int NOT NULL DEFAULT '0',
+  `VariationIndex` int NOT NULL DEFAULT '0',
+  `ColorIndex` int NOT NULL DEFAULT '0',
+  PRIMARY KEY (`ID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `charsections_dbc`
+--
+
+LOCK TABLES `charsections_dbc` WRITE;
+/*!40000 ALTER TABLE `charsections_dbc` DISABLE KEYS */;
+/*!40000 ALTER TABLE `charsections_dbc` ENABLE KEYS */;
+UNLOCK TABLES;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+-- Dump completed on 2026-02-16  1:03:19

--- a/data/sql/base/db_world/emotetextsound_dbc.sql
+++ b/data/sql/base/db_world/emotetextsound_dbc.sql
@@ -1,0 +1,53 @@
+-- MySQL dump 10.13  Distrib 8.4.8, for Linux (x86_64)
+--
+-- Host: localhost    Database: acore_world
+-- ------------------------------------------------------
+-- Server version	8.4.8
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!50503 SET NAMES utf8mb4 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+--
+-- Table structure for table `emotetextsound_dbc`
+--
+
+DROP TABLE IF EXISTS `emotetextsound_dbc`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `emotetextsound_dbc` (
+  `ID` int NOT NULL DEFAULT '0',
+  `EmotesTextID` int NOT NULL DEFAULT '0',
+  `RaceID` int NOT NULL DEFAULT '0',
+  `SexID` int NOT NULL DEFAULT '0',
+  `SoundID` int NOT NULL DEFAULT '0',
+  PRIMARY KEY (`ID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `emotetextsound_dbc`
+--
+
+LOCK TABLES `emotetextsound_dbc` WRITE;
+/*!40000 ALTER TABLE `emotetextsound_dbc` DISABLE KEYS */;
+/*!40000 ALTER TABLE `emotetextsound_dbc` ENABLE KEYS */;
+UNLOCK TABLES;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+-- Dump completed on 2026-02-16  1:03:20


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

The Playerbot branch added `LOAD_DBC` calls for `CharSections.dbc` and `EmotesTextSound.dbc` in `src/server/game/DataStores/DBCStores.cpp` (commit 29fbef3c9) but never created the corresponding `_dbc` base SQL table definitions. Every other `LOAD_DBC` call (110 of them) has a matching file in `data/sql/base/db_world/` — these two were missed.

Without the tables, `LoadFromDB()` triggers MySQL error 1146 (`ER_NO_SUCH_TABLE`), which `_HandleMySQLErrno` treats as fatal, aborting the worldserver on startup.

This PR adds the two missing empty table definitions, generated via `mysqldump` for consistency with the existing files.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

Claude (claude.ai/code) was used to investigate the root cause, identify both missing tables, and determine the correct column schemas from the DBC format strings and struct definitions.

## Issues Addressed:

- Worldserver fails to start with a fresh database due to missing `charsections_dbc` table (also reported in azerothcore/azerothcore-wotlk#16078)

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Column schemas derived from:
- `src/server/shared/DataStores/DBCfmt.h` — format strings `CharSectionsEntryfmt` and `EmotesTextSoundEntryfmt`
- `src/server/shared/DataStores/DBCStructure.h` — `CharSectionsEntry` and `EmotesTextSoundEntry` struct definitions
- Pattern-matched against all 110 existing `_dbc` base SQL files

## Tests Performed:

- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Start with a fresh database (delete the `ac-database` Docker volume or drop the `acore_world` database)
2. Run `docker compose up -d --build` to build and start all containers
3. Verify the worldserver starts successfully without `ER_NO_SUCH_TABLE` abort
4. Confirm both tables exist: `SELECT 1 FROM charsections_dbc LIMIT 1; SELECT 1 FROM emotetextsound_dbc LIMIT 1;`

## Known Issues and TODO List:

- [ ] None
