### PR TITLE
On Stop Combat Logic

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -7417,15 +7417,15 @@ bool Unit::AttackStop()
 
 void Unit::CombatStop(bool includingCast)
 {
+    sScriptMgr->OnUnitStopCombat(this);
     if (includingCast && IsNonMeleeSpellCast(false))
         InterruptNonMeleeSpells(false);
-
     AttackStop();
     RemoveAllAttackers();
     if (IsPlayer())
         ToPlayer()->SendAttackSwingCancelAttack();     // melee and ranged forced attack cancel
-    if (Creature* pCreature = ToCreature())
-        pCreature->ClearLastLeashExtensionTimePtr();
+    if (Creature* pCreature = ToCreature()){
+        pCreature->ClearLastLeashExtensionTimePtr();}
     ClearInCombat();
 
     // xinef: just in case

--- a/src/server/game/Scripting/ScriptDefines/UnitScript.cpp
+++ b/src/server/game/Scripting/ScriptDefines/UnitScript.cpp
@@ -123,7 +123,10 @@ void ScriptMgr::OnUnitEnterCombat(Unit* unit, Unit* victim)
 {
     CALL_ENABLED_HOOKS(UnitScript, UNITHOOK_ON_UNIT_ENTER_COMBAT, script->OnUnitEnterCombat(unit, victim));
 }
-
+void ScriptMgr::OnUnitStopCombat(Unit* unit)
+{
+    CALL_ENABLED_HOOKS(UnitScript, UNITHOOK_ON_UNIT_STOP_COMBAT, script->OnUnitStopCombat(unit));
+}
 void ScriptMgr::OnUnitDeath(Unit* unit, Unit* killer)
 {
     CALL_ENABLED_HOOKS(UnitScript, UNITHOOK_ON_UNIT_DEATH, script->OnUnitDeath(unit, killer));

--- a/src/server/game/Scripting/ScriptDefines/UnitScript.h
+++ b/src/server/game/Scripting/ScriptDefines/UnitScript.h
@@ -41,6 +41,7 @@ enum UnitHook
     UNITHOOK_ON_DISPLAYID_CHANGE,
     UNITHOOK_ON_UNIT_ENTER_EVADE_MODE,
     UNITHOOK_ON_UNIT_ENTER_COMBAT,
+    UNITHOOK_ON_UNIT_STOP_COMBAT,
     UNITHOOK_ON_UNIT_DEATH,
     UNITHOOK_ON_UNIT_SET_SHAPESHIFT_FORM,
     UNITHOOK_END
@@ -106,6 +107,7 @@ public:
 
     virtual void OnUnitEnterEvadeMode(Unit* /*unit*/, uint8 /*evadeReason*/) { }
     virtual void OnUnitEnterCombat(Unit* /*unit*/, Unit* /*victim*/) { }
+    virtual void OnUnitStopCombat(Unit* /*unit*/) {}
     virtual void OnUnitDeath(Unit* /*unit*/, Unit* /*killer*/) { }
     virtual void OnUnitSetShapeshiftForm(Unit* /*unit*/, uint8 /*form*/) { }
 };

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -579,6 +579,7 @@ public: /* UnitScript */
     void OnDisplayIdChange(Unit* unit, uint32 displayId);
     void OnUnitEnterEvadeMode(Unit* unit, uint8 why);
     void OnUnitEnterCombat(Unit* unit, Unit* victim);
+    void OnUnitStopCombat(Unit* unit);
     void OnUnitDeath(Unit* unit, Unit* killer);
     void OnUnitSetShapeshiftForm(Unit* unit, uint8 form);
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
Adds a hook to the UnitScript to allow for generic module logic to be applied when combat is finished.

### AI-assisted Pull Requests
AI was used as an assistant but code written by author

## Tests Performed:
I tested the code on an up to date branch of Playerbots running for two hours with bots.

## How to Test the Changes:
1. use the mod-mod-sync-level and with a GM character shift your level in combat, toggle GM mode, kill creatures, make creatures leash, evade, lose combat etc.

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
