### PR TITLE
add modules volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,6 +85,7 @@ services:
       - ${DOCKER_VOL_LOGS:-./env/dist/logs}:/azerothcore/env/dist/logs:delegated
       # client data
       - ${DOCKER_VOL_DATA:-ac-client-data}:/azerothcore/env/dist/data/:ro
+      - ./modules:/azerothcore/modules
     depends_on:
       ac-database:
         condition: service_healthy


### PR DESCRIPTION
Following https://github.com/mod-playerbots/mod-playerbots with docker installation results to

``` Directory "/azerothcore/modules/mod-playerbots/data/sql/playerbots/base/" not exists```

add modules to docker-compose.yml to fix it