### PR TITLE
Fixing jemalloc function signature

### DIFF
--- a/deps/jemalloc/include/jemalloc/internal/safety_check.h
+++ b/deps/jemalloc/include/jemalloc/internal/safety_check.h
@@ -3,7 +3,7 @@
 
 void safety_check_fail(const char *format, ...);
 /* Can set to NULL for a default. */
-void safety_check_set_abort(void (*abort_fn)());
+void safety_check_set_abort(void (*abort_fn)(const char *));
 
 JEMALLOC_ALWAYS_INLINE void
 safety_check_set_redzone(void *ptr, size_t usize, size_t bumped_usize) {


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> While the use of AI tools when preparing pull requests is not prohibited, contributors must clearly disclose when such tools have been used and specify the model involved.
> 
> Contributors are also expected to fully understand the changes they are submitting and must be able to explain and justify those changes when requested by maintainers.

- [ ] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Please specify which tools were used, if any.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

---

This minor change has enabled me to build my docker containers again.
Hope this is "proper" for a third party dependency fix.

How I was building:
```
cmake /opt/wotlk/core -DCMAKE_INSTALL_PREFIX=/opt/wotlk/core/env/dist/ -DWITH_WARNINGS=1 -DTOOLS_BUILD=all -DSCRIPTS=static -DMODULES=static
make -j$(nproc)
```

And the error I was getting prior to this change:
```
29.23 [  4%] Building C object deps/libmpq/CMakeFiles/mpq.dir/libmpq/mpq.c.o
29.26 [  4%] Building C object deps/jemalloc/CMakeFiles/jemalloc.dir/src/safety_check.c.o
29.61 [  4%] Building CXX object deps/g3dlite/CMakeFiles/g3dlib.dir/source/Capsule.cpp.o
29.61 In file included from /opt/wotlk/core/deps/jemalloc/src/safety_check.c:1:
29.61 /opt/wotlk/core/deps/jemalloc/include/jemalloc/internal/jemalloc_preamble.h:20:25: error: conflicting types for 'je_safety_check_set_abort'; have 'void(void (*)(const char *))'
29.61    20 | #  define JEMALLOC_N(n) je_##n
29.61       |                         ^~~
29.61 /opt/wotlk/core/deps/jemalloc/include/jemalloc/internal/private_namespace.h:354:32: note: in expansion of macro 'JEMALLOC_N'
29.61   354 | #define safety_check_set_abort JEMALLOC_N(safety_check_set_abort)
29.61       |                                ^~~~~~~~~~
29.61 /opt/wotlk/core/deps/jemalloc/src/safety_check.c:6:6: note: in expansion of macro 'safety_check_set_abort'
29.61     6 | void safety_check_set_abort(void (*abort_fn)(const char *)) {
29.61       |      ^~~~~~~~~~~~~~~~~~~~~~
29.61 /opt/wotlk/core/deps/jemalloc/include/jemalloc/internal/jemalloc_preamble.h:20:25: note: previous declaration of 'je_safety_check_set_abort' with type 'void(void (*)(void))'
29.61    20 | #  define JEMALLOC_N(n) je_##n
29.61       |                         ^~~
29.61 /opt/wotlk/core/deps/jemalloc/include/jemalloc/internal/private_namespace.h:354:32: note: in expansion of macro 'JEMALLOC_N'
29.61   354 | #define safety_check_set_abort JEMALLOC_N(safety_check_set_abort)
29.61       |                                ^~~~~~~~~~
29.61 /opt/wotlk/core/deps/jemalloc/include/jemalloc/internal/safety_check.h:6:6: note: in expansion of macro 'safety_check_set_abort'
29.61     6 | void safety_check_set_abort(void (*abort_fn)());
29.61       |      ^~~~~~~~~~~~~~~~~~~~~~
29.62 make[2]: *** [deps/jemalloc/CMakeFiles/jemalloc.dir/build.make:429: deps/jemalloc/CMakeFiles/jemalloc.dir/src/safety_check.c.o] Error 1
29.62 make[1]: *** [CMakeFiles/Makefile2:970: deps/jemalloc/CMakeFiles/jemalloc.dir/all] Error 2
29.62 make[1]: *** Waiting for unfinished jobs....
```