### PR TITLE
Refactor EquipmentSlots enum declaration (Companion PR)

### DIFF
--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -655,7 +655,7 @@ enum PlayerSlots
 
 #define INVENTORY_SLOT_BAG_0    255
 
-enum EquipmentSlots : uint32                                // 19 slots
+enum EquipmentSlots                                         // 19 slots
 {
     EQUIPMENT_SLOT_START        = 0,
     EQUIPMENT_SLOT_HEAD         = 0,


### PR DESCRIPTION
This must be merged alongside https://github.com/mod-playerbots/mod-playerbots/pull/2470 Details for change over there.

This reverts the declaration back to its form on AC.