### PR TITLE
deps/jemalloc: fix compilation error with Ubuntu 26.04 (libstdc++)

### DIFF
--- a/deps/jemalloc/src/jemalloc_cpp.cpp
+++ b/deps/jemalloc/src/jemalloc_cpp.cpp
@@ -67,7 +67,7 @@ handleOOM(std::size_t size, bool nothrow) {
 	}
 
 	if (ptr == nullptr && !nothrow)
-		std::__throw_bad_alloc();
+		throw std::bad_alloc();
 	return ptr;
 }
 


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Gemini (Assisted with modern toolchain compilation troubleshooting)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes 

Fix compilation error on Ubuntu 26.04 (modern libstdc++ compatibility with vendored jemalloc).

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author. (Built successfully and ran on Ubuntu 26.04 with GCC/libstdc++ 16)
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
1. Attempt to compile AzerothCore on a system running Ubuntu 26.04 or a modern Linux distribution utilizing libstdc++ 16+.
2. Verify that `deps/jemalloc` fails to compile with `std::__throw_bad_alloc()` errors prior to this patch.
3. Apply this patch and verify that the compilation completes successfully without errors.

## Known Issues and TODO List:
- None