### PR TITLE
Scripts: invoke private chat hook for whispers

### DIFF
--- a/src/server/game/Handlers/ChatHandler.cpp
+++ b/src/server/game/Handlers/ChatHandler.cpp
@@ -448,9 +448,6 @@ void WorldSession::HandleMessagechatOpcode(WorldPacket& recvData)
                 if (receiver->GetSession()->IsTrialAccount() && !receiver->IsInWhisperWhiteList(sender->GetGUID()))
                     receiver->AddWhisperWhiteList(sender->GetGUID());
 
-                if (!sScriptMgr->OnPlayerCanUseChat(sender, type, lang, msg, receiver))
-                    return;
-
                 GetPlayer()->Whisper(msg, Language(lang), receiver);
             }
             break;

--- a/src/server/game/Handlers/ChatHandler.cpp
+++ b/src/server/game/Handlers/ChatHandler.cpp
@@ -448,6 +448,9 @@ void WorldSession::HandleMessagechatOpcode(WorldPacket& recvData)
                 if (receiver->GetSession()->IsTrialAccount() && !receiver->IsInWhisperWhiteList(sender->GetGUID()))
                     receiver->AddWhisperWhiteList(sender->GetGUID());
 
+                if (!sScriptMgr->OnPlayerCanUseChat(sender, type, lang, msg, receiver))
+                    return;
+
                 GetPlayer()->Whisper(msg, Language(lang), receiver);
             }
             break;


### PR DESCRIPTION
## Summary
Invoke the existing `OnPlayerCanUseChat` script hook before delivering direct player whispers.

This lets modules observe and enrich private player-to-playerbot conversations without intercepting or blocking normal whisper delivery.

## Validation
Built `worldserver` and exercised with the accompanying `mod-llm-chatter` whisper-reply implementation.