### PR TITLE
fix: add MariaDB compatibility and LLM bridge profile

### DIFF
--- a/conf/dist/docker-compose.override.yml
+++ b/conf/dist/docker-compose.override.yml
@@ -1,4 +1,23 @@
 version: '3.8'
-# services:
-#   ac-worldserver-2:
-
+services:
+  ac-llm-chatter-bridge:
+    container_name: ac-llm-chatter-bridge
+    image: python:3.11-slim
+    networks:
+      - ac-network
+    working_dir: /app
+    environment:
+      - PYTHONUNBUFFERED=1
+    command: >
+      bash -c "
+        pip install --quiet -r /app/requirements.txt &&
+        python llm_chatter_bridge.py --config /config/mod_llm_chatter.conf
+      "
+    volumes:
+      - ./modules/mod-llm-chatter/tools:/app:ro
+      - ./env/dist/etc/modules:/config:ro
+    restart: unless-stopped
+    depends_on:
+      ac-database:
+        condition: service_healthy
+    profiles: [dev]

--- a/data/sql/archive/db_world/2025_11_28_05.sql
+++ b/data/sql/archive/db_world/2025_11_28_05.sql
@@ -1,5 +1,5 @@
 -- DB update 2025_11_28_04 -> 2025_11_28_05
-ALTER TABLE `spell_group` DROP `special_flag`;
+ALTER TABLE `spell_group` DROP COLUMN IF EXISTS `special_flag`;
 ALTER TABLE `spell_group` MODIFY COLUMN `spell_id` int;
 
 -- import from trinitycore
@@ -211,4 +211,4 @@ INSERT INTO `spell_group_stack_rules` (`group_id`,`stack_rule`, `description`) V
 (1126, 3, 'Stamina Buffs');
 
 DELETE FROM `spell_script_names` WHERE `spell_id` IN (18735, 56246, 56247);
-INSERT INTO `spell_script_names` VALUES (18735, 'spell_warl_voidwalker_pet_passive'); 
+INSERT INTO `spell_script_names` VALUES (18735, 'spell_warl_voidwalker_pet_passive');

--- a/data/sql/base/db_characters/world_state.sql
+++ b/data/sql/base/db_characters/world_state.sql
@@ -24,7 +24,7 @@ CREATE TABLE `world_state` (
   `Id` int unsigned NOT NULL COMMENT 'Internal save ID',
   `Data` longtext,
   PRIMARY KEY (`Id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='WorldState save system';
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='WorldState save system';
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/data/sql/base/db_world/player_shapeshift_model.sql
+++ b/data/sql/base/db_world/player_shapeshift_model.sql
@@ -27,7 +27,7 @@ CREATE TABLE `player_shapeshift_model` (
   `GenderID` tinyint unsigned NOT NULL,
   `ModelID` int unsigned NOT NULL,
   PRIMARY KEY (`ShapeshiftID`,`RaceID`,`CustomizationID`,`GenderID`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci PACK_KEYS=0;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci PACK_KEYS=0;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/data/sql/base/db_world/player_totem_model.sql
+++ b/data/sql/base/db_world/player_totem_model.sql
@@ -25,7 +25,7 @@ CREATE TABLE `player_totem_model` (
   `RaceID` tinyint unsigned NOT NULL,
   `ModelID` int unsigned NOT NULL,
   PRIMARY KEY (`TotemID`,`RaceID`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci PACK_KEYS=0;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci PACK_KEYS=0;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/data/sql/base/db_world/spawn_group.sql
+++ b/data/sql/base/db_world/spawn_group.sql
@@ -25,7 +25,7 @@ CREATE TABLE `spawn_group` (
   `spawnType` tinyint unsigned NOT NULL,
   `spawnId` int unsigned NOT NULL,
   PRIMARY KEY (`groupId`,`spawnType`,`spawnId`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/data/sql/base/db_world/spawn_group_template.sql
+++ b/data/sql/base/db_world/spawn_group_template.sql
@@ -25,7 +25,7 @@ CREATE TABLE `spawn_group_template` (
   `groupName` varchar(100) NOT NULL,
   `groupFlags` int unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`groupId`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/data/sql/base/db_world/spell_cone.sql
+++ b/data/sql/base/db_world/spell_cone.sql
@@ -24,7 +24,7 @@ CREATE TABLE `spell_cone` (
   `ID` int unsigned NOT NULL COMMENT 'Spell ID',
   `ConeDegrees` smallint NOT NULL DEFAULT '60' COMMENT 'Cone angle in degrees',
   PRIMARY KEY (`ID`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/data/sql/base/db_world/waypoint_data_addon.sql
+++ b/data/sql/base/db_world/waypoint_data_addon.sql
@@ -28,7 +28,7 @@ CREATE TABLE `waypoint_data_addon` (
   `PositionY` float NOT NULL DEFAULT '0',
   `PositionZ` float NOT NULL DEFAULT '0',
   PRIMARY KEY (`PathID`,`PointID`,`SplinePointIndex`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/src/server/database/Database/DatabaseWorkerPool.cpp
+++ b/src/server/database/Database/DatabaseWorkerPool.cpp
@@ -63,13 +63,8 @@ DatabaseWorkerPool<T>::DatabaseWorkerPool() :
 {
     WPFatal(mysql_thread_safe(), "Used MySQL library isn't thread-safe.");
 
-    bool isSupportClientDB = mysql_get_client_version() >= MIN_MYSQL_CLIENT_VERSION;
-    bool isSameClientDB = mysql_get_client_version() == MYSQL_VERSION_ID;
-
-    WPFatal(isSupportClientDB, "AzerothCore does not support MySQL versions below 8.0\n\nFound version: {} / {}. Server compiled with: {}.\nSearch the wiki for ACE00043 in Common Errors (https://www.azerothcore.org/wiki/common-errors#ace00043).",
-        mysql_get_client_info(), mysql_get_client_version(), MYSQL_VERSION_ID);
-    WPFatal(isSameClientDB, "Used MySQL library version ({} id {}) does not match the version id used to compile AzerothCore (id {}).\nSearch the wiki for ACE00046 in Common Errors (https://www.azerothcore.org/wiki/common-errors#ace00046).",
-        mysql_get_client_info(), mysql_get_client_version(), MYSQL_VERSION_ID);
+    bool isSupportClientDB = true;
+    bool isSameClientDB = true;
 }
 
 template <class T>
@@ -390,32 +385,7 @@ void DatabaseWorkerPool<T>::KeepAlive()
 */
 bool DatabaseIncompatibleVersion(std::string const mysqlVersion)
 {
-    // anon func to turn a version string into an array of uint8
-    // "1.2.3" => [1, 2, 3]
-    auto parse = [](std::string const& input)
-    {
-        std::vector<uint8> result;
-        std::istringstream parser(input);
-        result.push_back(parser.get());
-        for (int i = 1; i < 3; i++)
-        {
-            // Skip period
-            parser.get();
-            // Append int from parser to output
-            result.push_back(parser.get());
-        }
-        return result;
-    };
-
-    // default to values for MySQL
-    uint8 offset = 0;
-    std::string minVersion = MIN_MYSQL_SERVER_VERSION;
-
-    auto parsedMySQLVersion = parse(mysqlVersion.substr(offset));
-    auto parsedMinVersion = parse(minVersion);
-
-    return std::lexicographical_compare(parsedMySQLVersion.begin(), parsedMySQLVersion.end(),
-                                        parsedMinVersion.begin(), parsedMinVersion.end());
+    return false;
 }
 
 template <class T>


### PR DESCRIPTION
Adds MariaDB 10.11 install compatibility: avoids MySQL-client/server version hard failures, replaces MySQL-8-only 0900 collations in base SQL, makes one archive migration retry-safe, and provides an optional LLM Chatter bridge Docker profile.