### PR TITLE
Init server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,6 @@
 /apps/joiner
 /deps/deno
 /data/sql/custom/*
-/src/server/scripts/Custom/*
 !/src/server/scripts/Custom/README.md
 
 /*.override.yml

--- a/data/sql/updates/pending_db_world/rev_1787377390451498201.sql
+++ b/data/sql/updates/pending_db_world/rev_1787377390451498201.sql
@@ -1,0 +1,14 @@
+-- Custom: repurpose the (previously-unused) CR_WEAPON_SKILL_MAINHAND/OFFHAND/RANGED combat rating
+-- slots (ids 20/21/22) into CR_MASTERY/CR_VERSATILITY/CR_COOLDOWN_REDUCTION - see Unit.h.
+-- Their old `gtcombatratings_dbc` curves are shaped for converting rating into weapon-skill points,
+-- not a percent, so they are overwritten here with a copy of the CR_CRIT_MELEE (id 8) percentage
+-- curve, giving the 3 new stats a sane, already level-tuned percent-per-rating baseline. Balance can
+-- be retuned later by editing `Data` directly - no code change needed.
+-- `gtoctclasscombatratingscalar_dbc` needs no change: its rows for ids 20/21/22 are already a flat
+-- `1` scalar per class, identical to CR_CRIT_MELEE's own scalar rows.
+DELETE FROM `gtcombatratings_dbc` WHERE `ID` BETWEEN 2000 AND 2099;
+INSERT INTO `gtcombatratings_dbc` (`ID`, `Data`) SELECT `ID` + 1200, `Data` FROM `gtcombatratings_dbc` WHERE `ID` BETWEEN 800 AND 899;
+DELETE FROM `gtcombatratings_dbc` WHERE `ID` BETWEEN 2100 AND 2199;
+INSERT INTO `gtcombatratings_dbc` (`ID`, `Data`) SELECT `ID` + 1300, `Data` FROM `gtcombatratings_dbc` WHERE `ID` BETWEEN 800 AND 899;
+DELETE FROM `gtcombatratings_dbc` WHERE `ID` BETWEEN 2200 AND 2299;
+INSERT INTO `gtcombatratings_dbc` (`ID`, `Data`) SELECT `ID` + 1400, `Data` FROM `gtcombatratings_dbc` WHERE `ID` BETWEEN 800 AND 899;

--- a/src/server/apps/worldserver/worldserver.conf.dist
+++ b/src/server/apps/worldserver/worldserver.conf.dist
@@ -2513,10 +2513,14 @@ MaxGroupXPDistance = 74
 #                     1 - (Rate.XP.Quest.DF) - Dungeon Finder/LFG quests only.
 #                     1 - (Rate.XP.Explore)
 #                     1 - (Rate.XP.Pet)
+#        Note:        Quest XP is boosted 10x on this server. Regular (non-boss) creature kill XP
+#                     is intentionally left alone; dungeon boss kills get their own 10x bonus via
+#                     Custom.XP.DungeonBoss.Rate below (see CUSTOM section), since Rate.XP.Kill
+#                     applies to every creature kill, not just bosses.
 
 Rate.XP.Kill      = 1
-Rate.XP.Quest     = 1
-Rate.XP.Quest.DF  = 1
+Rate.XP.Quest     = 10
+Rate.XP.Quest.DF  = 10
 Rate.XP.Explore   = 1
 Rate.XP.Pet       = 1
 
@@ -4808,6 +4812,15 @@ Daze.Enabled = 1
 #        Default:     0 - (Blizzlike)
 
 InfiniteAmmo.Enabled = 0
+
+#
+#    Custom.XP.DungeonBoss.Rate
+#        Description: Extra experience multiplier applied on top of Rate.XP.Kill when the slain
+#                     creature is a dungeon boss (Creature::IsDungeonBoss(), i.e. registered as
+#                     instance boss data). Implemented by src/server/scripts/Custom/custom_xp_rates.cpp.
+#        Default:     10
+
+Custom.XP.DungeonBoss.Rate = 10
 
 #
 ###################################################################################################

--- a/src/server/game/Entities/Item/ItemTemplate.h
+++ b/src/server/game/Entities/Item/ItemTemplate.h
@@ -41,9 +41,9 @@ enum ItemModType
     ITEM_MOD_CRIT_MELEE_RATING        = 19,
     ITEM_MOD_CRIT_RANGED_RATING       = 20,
     ITEM_MOD_CRIT_SPELL_RATING        = 21,
-    ITEM_MOD_HIT_TAKEN_MELEE_RATING   = 22,
-    ITEM_MOD_HIT_TAKEN_RANGED_RATING  = 23,
-    ITEM_MOD_HIT_TAKEN_SPELL_RATING   = 24,
+    ITEM_MOD_MASTERY_RATING           = 22, // Custom: was ITEM_MOD_HIT_TAKEN_MELEE_RATING (unused in this fork's item_template)
+    ITEM_MOD_VERSATILITY_RATING       = 23, // Custom: was ITEM_MOD_HIT_TAKEN_RANGED_RATING (unused in this fork's item_template)
+    ITEM_MOD_COOLDOWN_RATING          = 24, // Custom: was ITEM_MOD_HIT_TAKEN_SPELL_RATING (unused in this fork's item_template)
     ITEM_MOD_CRIT_TAKEN_MELEE_RATING  = 25,
     ITEM_MOD_CRIT_TAKEN_RANGED_RATING = 26,
     ITEM_MOD_CRIT_TAKEN_SPELL_RATING  = 27,
@@ -52,7 +52,7 @@ enum ItemModType
     ITEM_MOD_HASTE_SPELL_RATING       = 30,
     ITEM_MOD_HIT_RATING               = 31,
     ITEM_MOD_CRIT_RATING              = 32,
-    ITEM_MOD_HIT_TAKEN_RATING         = 33,
+    ITEM_MOD_PROC_RATING              = 33, // Custom: was ITEM_MOD_HIT_TAKEN_RATING (unused in this fork's item_template)
     ITEM_MOD_CRIT_TAKEN_RATING        = 34,
     ITEM_MOD_RESILIENCE_RATING        = 35,
     ITEM_MOD_HASTE_RATING             = 36,

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -6896,14 +6896,14 @@ void Player::_ApplyItemBonuses(ItemTemplate const* proto, uint8 slot, bool apply
             case ITEM_MOD_CRIT_SPELL_RATING:
                 ApplyRatingMod(CR_CRIT_SPELL, int32(val), apply);
                 break;
-            case ITEM_MOD_HIT_TAKEN_MELEE_RATING:
-                ApplyRatingMod(CR_HIT_TAKEN_MELEE, int32(val), apply);
+            case ITEM_MOD_MASTERY_RATING: // Custom stat
+                ApplyRatingMod(CR_MASTERY, int32(val), apply);
                 break;
-            case ITEM_MOD_HIT_TAKEN_RANGED_RATING:
-                ApplyRatingMod(CR_HIT_TAKEN_RANGED, int32(val), apply);
+            case ITEM_MOD_VERSATILITY_RATING: // Custom stat
+                ApplyRatingMod(CR_VERSATILITY, int32(val), apply);
                 break;
-            case ITEM_MOD_HIT_TAKEN_SPELL_RATING:
-                ApplyRatingMod(CR_HIT_TAKEN_SPELL, int32(val), apply);
+            case ITEM_MOD_COOLDOWN_RATING: // Custom stat
+                ApplyRatingMod(CR_COOLDOWN_REDUCTION, int32(val), apply);
                 break;
             case ITEM_MOD_CRIT_TAKEN_MELEE_RATING:
                 ApplyRatingMod(CR_CRIT_TAKEN_MELEE, int32(val), apply);
@@ -6933,10 +6933,8 @@ void Player::_ApplyItemBonuses(ItemTemplate const* proto, uint8 slot, bool apply
                 ApplyRatingMod(CR_CRIT_RANGED, int32(val), apply);
                 ApplyRatingMod(CR_CRIT_SPELL, int32(val), apply);
                 break;
-            case ITEM_MOD_HIT_TAKEN_RATING:
-                ApplyRatingMod(CR_HIT_TAKEN_MELEE, int32(val), apply);
-                ApplyRatingMod(CR_HIT_TAKEN_RANGED, int32(val), apply);
-                ApplyRatingMod(CR_HIT_TAKEN_SPELL, int32(val), apply);
+            case ITEM_MOD_PROC_RATING: // Custom stat
+                ApplyRatingMod(CR_PROC_CHANCE, int32(val), apply);
                 break;
             case ITEM_MOD_CRIT_TAKEN_RATING:
             case ITEM_MOD_RESILIENCE_RATING:
@@ -11160,6 +11158,11 @@ void Player::AddSpellAndCategoryCooldowns(SpellInfo const* spellInfo, uint32 ite
                 rec += cooldownMod * IN_MILLISECONDS;   // SPELL_AURA_MOD_COOLDOWN does not affect category cooldows, verified with shaman shocks
             }
         }
+
+        // Custom: Cooldown Reduction stat - only affects abilities whose baseline (unmodified)
+        // cooldown is longer than 30 seconds.
+        if (rec > 30000 && spellInfo->RecoveryTime > 30000)
+            rec = int32(rec * (1.0f - GetCooldownReductionPercentage() / 100.0f));
 
         // replace negative cooldowns by 0
         if (rec < 0) rec = 0;

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -1998,6 +1998,11 @@ public:
     float OCTRegenMPPerSpirit();
     [[nodiscard]] float GetRatingMultiplier(CombatRating cr) const;
     [[nodiscard]] float GetRatingBonusValue(CombatRating cr) const;
+    // Custom stats: percentage value derived from the corresponding CombatRating.
+    [[nodiscard]] float GetMasteryPercentage() const { return GetRatingBonusValue(CR_MASTERY); }
+    [[nodiscard]] float GetVersatilityPercentage() const { return GetRatingBonusValue(CR_VERSATILITY); }
+    [[nodiscard]] float GetCooldownReductionPercentage() const { return GetRatingBonusValue(CR_COOLDOWN_REDUCTION); }
+    [[nodiscard]] float GetProcChancePercentage() const { return GetRatingBonusValue(CR_PROC_CHANCE); }
     uint32 GetBaseSpellPowerBonus() { return m_baseSpellPower; }
     uint32 GetBaseSpellDamageBonus() { return m_baseSpellDamage; }
     uint32 GetBaseSpellHealingBonus() { return m_baseSpellHealing; }

--- a/src/server/game/Entities/Player/PlayerUpdates.cpp
+++ b/src/server/game/Entities/Player/PlayerUpdates.cpp
@@ -670,7 +670,8 @@ void Player::UpdateRating(CombatRating cr)
         if (affectStats)
             UpdateAllSpellCritChances();
         break;
-    case CR_HIT_TAKEN_MELEE: // Implemented in Unit::MeleeMissChanceCalc
+    case CR_PROC_CHANCE: // Custom: was CR_HIT_TAKEN_MELEE - read live wherever procs are rolled
+        break;
     case CR_HIT_TAKEN_RANGED:
         break;
     case CR_HIT_TAKEN_SPELL: // Implemented in Unit::MagicSpellHitResult
@@ -686,10 +687,9 @@ void Player::UpdateRating(CombatRating cr)
     case CR_HASTE_RANGED:
     case CR_HASTE_SPELL:
         break;
-    case CR_WEAPON_SKILL_MAINHAND: // Implemented in
-                                   // Unit::RollMeleeOutcomeAgainst
-    case CR_WEAPON_SKILL_OFFHAND:
-    case CR_WEAPON_SKILL_RANGED:
+    case CR_MASTERY: // Custom: was CR_WEAPON_SKILL_MAINHAND - read live via GetMasteryPercentage()
+    case CR_VERSATILITY: // Custom: was CR_WEAPON_SKILL_OFFHAND - read live via GetVersatilityPercentage()
+    case CR_COOLDOWN_REDUCTION: // Custom: was CR_WEAPON_SKILL_RANGED - read live via GetCooldownReductionPercentage()
         break;
     case CR_EXPERTISE:
         if (affectStats)

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -3339,7 +3339,9 @@ SpellMissInfo Unit::MeleeSpellHitResult(Unit* victim, SpellInfo const* spellInfo
 
     uint32 roll = urand (0, 10000);
 
-    uint32 missChance = uint32(MeleeSpellMissChance(victim, attType, skillDiff, spellInfo->Id) * 100.0f);
+    // Custom: Hit is no longer a meaningful player stat - players always land melee-classed
+    // spells against non-player targets (PvE only; dodge/parry/block/resist below are untouched).
+    uint32 missChance = (IsPlayer() && !victim->IsPlayer()) ? 0 : uint32(MeleeSpellMissChance(victim, attType, skillDiff, spellInfo->Id) * 100.0f);
     // Roll miss
     uint32 tmp = missChance;
     if (roll < tmp)
@@ -3567,6 +3569,11 @@ SpellMissInfo Unit::MagicSpellHitResult(Unit* victim, SpellInfo const* spellInfo
     if (HitChance < 100)
         HitChance = 100;
     else if (HitChance > 10000)
+        HitChance = 10000;
+
+    // Custom: Hit is no longer a meaningful player stat - players always land spells against
+    // non-player targets (PvE only; resist/deflect rolls below are untouched).
+    if (IsPlayer() && !victim->IsPlayer())
         HitChance = 10000;
 
     int32 tmp = 10000 - HitChance;
@@ -3961,21 +3968,11 @@ uint32 Unit::GetWeaponSkillValue (WeaponAttackType attType, Unit const* target) 
                 ? player->GetMaxSkillValue(skill)
                 : player->GetSkillValue(skill);
         // Modify value from ratings
+        // Custom: per-attack-type weapon skill ratings (CR_WEAPON_SKILL_MAINHAND/OFFHAND/RANGED)
+        // were never written by any item/aura and have been repurposed into CR_MASTERY/
+        // CR_VERSATILITY/CR_COOLDOWN_REDUCTION - see Unit.h. Only the flat CR_WEAPON_SKILL
+        // (id 0) still applies here.
         value += uint32(player->GetRatingBonusValue(CR_WEAPON_SKILL));
-        switch (attType)
-        {
-            case BASE_ATTACK:
-                value += uint32(player->GetRatingBonusValue(CR_WEAPON_SKILL_MAINHAND));
-                break;
-            case OFF_ATTACK:
-                value += uint32(player->GetRatingBonusValue(CR_WEAPON_SKILL_OFFHAND));
-                break;
-            case RANGED_ATTACK:
-                value += uint32(player->GetRatingBonusValue(CR_WEAPON_SKILL_RANGED));
-                break;
-            default:
-                break;
-        }
     }
     else
         value = GetUnitMeleeSkill(target);
@@ -8470,6 +8467,10 @@ float Unit::SpellPctDamageModsDone(Unit* victim, SpellInfo const* spellProto, Da
     // Done total percent damage auras
     float DoneTotalMod = 1.0f;
 
+    // Custom: Versatility increases damage done
+    if (IsPlayer())
+        DoneTotalMod *= 1.0f + ToPlayer()->GetVersatilityPercentage() / 100.0f;
+
     DoneTotalMod *= GetTotalAuraMultiplier(SPELL_AURA_MOD_DAMAGE_PERCENT_DONE, [spellProto, this, damagetype](AuraEffect const* aurEff)
     {
         // prevent apply mods from weapon specific case to non weapon specific spells (Example: thunder clap and two-handed weapon specialization)
@@ -8956,6 +8957,10 @@ uint32 Unit::SpellDamageBonusTaken(Unit* caster, SpellInfo const* spellProto, ui
     // multiplicative bonus, for example Dispersion + Shadowform (0.10*0.85=0.085)
     TakenTotalMod *= GetTotalAuraMultiplierByMiscMask(SPELL_AURA_MOD_DAMAGE_PERCENT_TAKEN, spellProto->GetSchoolMask());
 
+    // Custom: Versatility reduces damage taken at half rate
+    if (IsPlayer())
+        TakenTotalMod *= 1.0f - ToPlayer()->GetVersatilityPercentage() / 200.0f;
+
     TakenTotalMod = processDummyAuras(TakenTotalMod);
 
     // From caster spells
@@ -9097,6 +9102,9 @@ int32 Unit::SpellBaseDamageBonusDone(SpellSchoolMask schoolMask)
         // Base value
         DoneAdvertisedBenefit += ToPlayer()->GetBaseSpellPowerBonus();
         DoneAdvertisedBenefit += ToPlayer()->GetBaseSpellDamageBonus();
+
+        // Custom: 1 point of spellpower per point of Intellect and Spirit
+        DoneAdvertisedBenefit += int32(GetStat(STAT_INTELLECT)) + int32(GetStat(STAT_SPIRIT));
 
         // Damage bonus from stats
         AuraEffectList const& mDamageDoneOfStatPercent = GetAuraEffectsByType(SPELL_AURA_MOD_SPELL_DAMAGE_OF_STAT_PERCENT);
@@ -9523,6 +9531,10 @@ float Unit::SpellPctHealingModsDone(Unit* victim, SpellInfo const* spellProto, D
 
     float DoneTotalMod = 1.0f;
 
+    // Custom: Versatility increases healing done
+    if (IsPlayer())
+        DoneTotalMod *= 1.0f + ToPlayer()->GetVersatilityPercentage() / 100.0f;
+
     // Healing done percent
     if (includeHealingDonePct)
         DoneTotalMod *= GetTotalAuraMultiplier(SPELL_AURA_MOD_HEALING_DONE_PERCENT);
@@ -9853,6 +9865,9 @@ int32 Unit::SpellBaseHealingBonusDone(SpellSchoolMask schoolMask)
         // Base value
         AdvertisedBenefit += ToPlayer()->GetBaseSpellPowerBonus();
         AdvertisedBenefit += ToPlayer()->GetBaseSpellHealingBonus();
+
+        // Custom: 1 point of spellpower per point of Intellect and Spirit
+        AdvertisedBenefit += int32(GetStat(STAT_INTELLECT)) + int32(GetStat(STAT_SPIRIT));
 
         // Healing bonus from stats
         AuraEffectList const& mHealingDoneOfStatPercent = GetAuraEffectsByType(SPELL_AURA_MOD_SPELL_HEALING_OF_STAT_PERCENT);
@@ -10240,6 +10255,10 @@ uint32 Unit::MeleeDamageBonusDone(Unit* victim, uint32 pdamage, WeaponAttackType
     // Done total percent damage auras
     float DoneTotalMod = 1.0f;
 
+    // Custom: Versatility increases damage done
+    if (IsPlayer())
+        DoneTotalMod *= 1.0f + ToPlayer()->GetVersatilityPercentage() / 100.0f;
+
     // mods for SPELL_SCHOOL_MASK_NORMAL are already factored in base melee damage calculation
     if (!(damageSchoolMask & SPELL_SCHOOL_MASK_NORMAL))
     {
@@ -10387,6 +10406,10 @@ uint32 Unit::MeleeDamageBonusTaken(Unit* attacker, uint32 pdamage, WeaponAttackT
 
     // Taken total percent damage auras
     float TakenTotalMod = 1.0f;
+
+    // Custom: Versatility reduces damage taken at half rate
+    if (IsPlayer())
+        TakenTotalMod *= 1.0f - ToPlayer()->GetVersatilityPercentage() / 200.0f;
 
     TakenTotalMod *= GetTotalAuraMultiplierByMiscMask(SPELL_AURA_MOD_DAMAGE_PERCENT_TAKEN, damageSchoolMask);
 

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -232,7 +232,7 @@ enum CombatRating : uint8
     CR_CRIT_MELEE               = 8,
     CR_CRIT_RANGED              = 9,
     CR_CRIT_SPELL               = 10,
-    CR_HIT_TAKEN_MELEE          = 11,
+    CR_PROC_CHANCE              = 11, // Custom: was CR_HIT_TAKEN_MELEE (unused - never written by any item/aura)
     CR_HIT_TAKEN_RANGED         = 12,
     CR_HIT_TAKEN_SPELL          = 13,
     CR_CRIT_TAKEN_MELEE         = 14,
@@ -241,9 +241,9 @@ enum CombatRating : uint8
     CR_HASTE_MELEE              = 17,
     CR_HASTE_RANGED             = 18,
     CR_HASTE_SPELL              = 19,
-    CR_WEAPON_SKILL_MAINHAND    = 20,
-    CR_WEAPON_SKILL_OFFHAND     = 21,
-    CR_WEAPON_SKILL_RANGED      = 22,
+    CR_MASTERY                  = 20, // Custom: was CR_WEAPON_SKILL_MAINHAND (unused - never written by any item/aura)
+    CR_VERSATILITY              = 21, // Custom: was CR_WEAPON_SKILL_OFFHAND (unused - never written by any item/aura)
+    CR_COOLDOWN_REDUCTION       = 22, // Custom: was CR_WEAPON_SKILL_RANGED (unused - never written by any item/aura)
     CR_EXPERTISE                = 23,
     CR_ARMOR_PENETRATION        = 24
 };

--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -2303,6 +2303,11 @@ float Aura::CalcProcChance(SpellProcEntry const& procEntry, ProcEventInfo& event
     if ((procEntry.AttributesMask & PROC_ATTR_REDUCE_PROC_60) && eventInfo.GetActor()->GetLevel() > 60)
         chance = std::max(0.f, (1.f - ((eventInfo.GetActor()->GetLevel() - 60) * 1.f / 30.f)) * chance);
 
+    // Custom: Proc Chance stat increases the chance of any aura-driven proc (talents, item procs, ...)
+    if (Unit* caster = GetCaster())
+        if (caster->IsPlayer())
+            chance *= 1.0f + caster->ToPlayer()->GetProcChancePercentage() / 100.0f;
+
     return chance;
 }
 

--- a/src/server/scripts/Custom/custom_pve_always_hit.cpp
+++ b/src/server/scripts/Custom/custom_pve_always_hit.cpp
@@ -1,0 +1,46 @@
+/*
+ * This file is part of the AzerothCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Custom: Hit is no longer a meaningful player stat - players always land white melee/ranged
+// auto-attacks against non-player targets (PvE only; PvP hit/miss is untouched). Spell hit chance
+// vs. NPCs is handled separately in Unit::MeleeSpellHitResult / Unit::MagicSpellHitResult
+// (Unit.cpp), since no equivalent script hook exists on those paths.
+
+#include "ScriptMgr.h"
+#include "Unit.h"
+
+class Custom_PvEAlwaysHit : public UnitScript
+{
+public:
+    Custom_PvEAlwaysHit() : UnitScript("Custom_PvEAlwaysHit") { }
+
+    void OnBeforeRollMeleeOutcomeAgainst(Unit const* attacker, Unit const* victim, WeaponAttackType /*attType*/,
+        int32& /*attackerMaxSkillValueForLevel*/, int32& /*victimMaxSkillValueForLevel*/,
+        int32& /*attackerWeaponSkill*/, int32& /*victimDefenseSkill*/, int32& /*crit_chance*/,
+        int32& miss_chance, int32& /*dodge_chance*/, int32& /*parry_chance*/, int32& /*block_chance*/) override
+    {
+        if (attacker->IsPlayer() && !victim->IsPlayer())
+        {
+            miss_chance = 0;
+        }
+    }
+};
+
+void AddSC_custom_pve_always_hit()
+{
+    new Custom_PvEAlwaysHit();
+}

--- a/src/server/scripts/Custom/custom_script_loader.cpp
+++ b/src/server/scripts/Custom/custom_script_loader.cpp
@@ -18,10 +18,12 @@
 // This is where scripts' loading functions should be declared:
 // void MyExampleScript()
 void AddSC_custom_xp_rates();
+void AddSC_custom_pve_always_hit();
 
 // The name of this function should match:
 // void Add${NameOfDirectory}Scripts()
 void AddCustomScripts()
 {
     AddSC_custom_xp_rates();
+    AddSC_custom_pve_always_hit();
 }

--- a/src/server/scripts/Custom/custom_script_loader.cpp
+++ b/src/server/scripts/Custom/custom_script_loader.cpp
@@ -17,10 +17,11 @@
 
 // This is where scripts' loading functions should be declared:
 // void MyExampleScript()
+void AddSC_custom_xp_rates();
 
 // The name of this function should match:
 // void Add${NameOfDirectory}Scripts()
 void AddCustomScripts()
 {
-    // MyExampleScript()
+    AddSC_custom_xp_rates();
 }

--- a/src/server/scripts/Custom/custom_xp_rates.cpp
+++ b/src/server/scripts/Custom/custom_xp_rates.cpp
@@ -1,0 +1,56 @@
+/*
+ * This file is part of the AzerothCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Custom: dungeon boss kills grant bonus XP on top of Rate.XP.Kill.
+// Quest XP is boosted separately via Rate.XP.Quest / Rate.XP.Quest.DF in worldserver.conf - no
+// script needed there, since that rate already only applies to quest rewards. Rate.XP.Kill, on
+// the other hand, applies to every creature kill, so a plain rate bump would also buff trash
+// mobs. This script instead multiplies only kills of creatures flagged as dungeon bosses
+// (Creature::IsDungeonBoss(), set dynamically for creatures registered as instance boss data).
+
+#include "Config.h"
+#include "Creature.h"
+#include "Player.h"
+#include "ScriptMgr.h"
+
+class Custom_XPRates : public PlayerScript
+{
+public:
+    Custom_XPRates() : PlayerScript("Custom_XPRates") { }
+
+    void OnPlayerGiveXP(Player* /*player*/, uint32& amount, Unit* victim, uint8 xpSource) override
+    {
+        if (xpSource != PlayerXPSource::XPSOURCE_KILL || !victim)
+        {
+            return;
+        }
+
+        Creature const* creature = victim->ToCreature();
+        if (!creature || !creature->IsDungeonBoss())
+        {
+            return;
+        }
+
+        static float const rate = sConfigMgr->GetOption<float>("Custom.XP.DungeonBoss.Rate", 10.0f);
+        amount = uint32(amount * rate);
+    }
+};
+
+void AddSC_custom_xp_rates()
+{
+    new Custom_XPRates();
+}


### PR DESCRIPTION
Setting up the 10x XP from quests and bosses.

Setting up all of the modules

Shared core-combat change for both realms:

- Intellect and Spirit each grant 1 flat spellpower (Unit::SpellBaseDamageBonusDone/
  SpellBaseHealingBonusDone), guarded to players only.

- Four new gear stats - Mastery, Versatility, Cooldown Reduction, Proc Chance - added by
  repurposing 4 combat rating / item mod slots confirmed (via a live DB query) to be written
  by zero items and no other code: CR_WEAPON_SKILL_MAINHAND/OFFHAND/RANGED -> CR_MASTERY/
  CR_VERSATILITY/CR_COOLDOWN_REDUCTION, CR_HIT_TAKEN_MELEE -> CR_PROC_CHANCE, with matching
  ITEM_MOD_* renames. Numeric enum values are unchanged, only names.

  Old gtcombatratings_dbc curves for those rating ids were shaped for weapon-skill points,
  not a percent stat, so the SQL migration overwrites them with a copy of CR_CRIT_MELEE's
  already level-tuned percent curve. gtoctclasscombatratingscalar_dbc needed no change.

  Versatility is wired into the 5 existing damage/healing "total mod" percent-assembly
  functions (+done, -taken at half rate). Cooldown Reduction reduces cooldowns >30s baseline
  in Player::AddSpellAndCategoryCooldowns. Proc Chance hooks the single Aura::CalcProcChance
  chokepoint used by all proc rolls. Mastery is infrastructure only (Player::
  GetMasteryPercentage()) with no gameplay hookup yet - itemization is a follow-up.

- Players always hit non-player targets (PvE only, PvP untouched): melee/ranged auto-attack
  via a new UnitScript (custom_pve_always_hit.cpp, no core edit needed); melee-classed and
  magic spells needed direct edits to Unit::MeleeSpellHitResult/MagicSpellHitResult since no
  script hook exists there. Dodge/parry/block/resist are untouched.